### PR TITLE
HOTFIX Catch errors from bad creator field

### DIFF
--- a/src/parseRDF.js
+++ b/src/parseRDF.js
@@ -146,8 +146,12 @@ exports.getAgents = (ebook, lcRels) => {
     const roleTerm = `marcrel:${rel[0]}`
 
     if (roleTerm in ebook) {
-      const ent = exports.getAgent(ebook[roleTerm][0]['pgterms:agent'][0], rel[1])
-      agents.push(ent)
+      try {
+        const ent = exports.getAgent(ebook[roleTerm][0]['pgterms:agent'][0], rel[1])
+        agents.push(ent)
+      } catch (err) {
+        // Do nothing
+      }
     }
   })
 


### PR DESCRIPTION
An error where a creator could not be found in a Gutenberg record was crashing the inbex process. This simply catches the error and continues the process as we've discussed it can be a valid instance for a record to have no assigned creator. If this turns into a more frequent occurence then more investigation will be warranted.