### PR TITLE
Hotfix Add VIAF lookup

### DIFF
--- a/src/parseRDF.js
+++ b/src/parseRDF.js
@@ -41,11 +41,11 @@ exports.parseRDF = (data, gutenbergID, gutenbergURI, lcRels, callback) => {
   const rdfData = data.data.repository.object
   const rdfText = rdfData.text
   // Read XML/RDF string into javascript object
-  parseString(rdfText, (err, result) => {
+  parseString(rdfText, async (err, result) => {
     if (err) return callback(err, null)
 
     // On success, parse resulting object into Metadata Model Object
-    const gutenbergData = exports.loadGutenbergRecord(result['rdf:RDF'], gutenbergID, lcRels)
+    const gutenbergData = await exports.loadGutenbergRecord(result['rdf:RDF'], gutenbergID, lcRels)
     callback(null, gutenbergData)
   })
 }
@@ -54,7 +54,7 @@ exports.parseRDF = (data, gutenbergID, gutenbergURI, lcRels, callback) => {
 // This does the transformation work from RDF to the SFR standard
 // It relies on models imported from sfrMetadataModel, which defines each
 // type of record created here
-exports.loadGutenbergRecord = (rdf, gutenbergID, lcRels) => {
+exports.loadGutenbergRecord = async (rdf, gutenbergID, lcRels) => {
   // Load main metadata blocks from RDF
   const ebook = rdf['pgterms:ebook'][0]
   const work = rdf['cc:Work'][0]
@@ -83,7 +83,7 @@ exports.loadGutenbergRecord = (rdf, gutenbergID, lcRels) => {
   bibRecord.subjects = exports.getSubjects(ebook['dcterms:subject'])
 
   // Add Agents to the work
-  bibRecord.agents = exports.getAgents(ebook, lcRels)
+  bibRecord.agents = await exports.getAgents(ebook, lcRels)
 
   // Add a rights statement to the work
   const license = exports.getFieldAttrib(work['cc:license'][0], 'rdf:resource')
@@ -126,16 +126,36 @@ exports.loadGutenbergRecord = (rdf, gutenbergID, lcRels) => {
   return bibRecord
 }
 
+const getMARCRelAgents = async (rels, ebook) => {
+  const agents = []
+  for (let i = 0; i < rels.length; i++) {
+    const roleTerm = `marcrel:${rels[i][0]}`
+
+    if (roleTerm in ebook) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const ent = await exports.getAgent(
+          ebook[roleTerm][0]['pgterms:agent'][0], rels[i][1],
+        )
+        agents.push(ent)
+      } catch (err) {
+        // Do nothing
+      }
+    }
+  }
+  return agents
+}
+
 // Load agents from the RDF block
 // This loads the special "creator" field as well as the arbitrarily defined
 // marcrel relationships, which it scans the document for
-exports.getAgents = (ebook, lcRels) => {
+exports.getAgents = async (ebook, lcRels) => {
   const agents = []
 
   // Try to load a creator. Not all RDF files have creators associated, so
   // this will catch any error if it does not exist
   try {
-    const creator = exports.getAgent(ebook['dcterms:creator'][0]['pgterms:agent'][0], 'author')
+    const creator = await exports.getAgent(ebook['dcterms:creator'][0]['pgterms:agent'][0], 'author')
     agents.push(creator)
   } catch (e) {
     if (e instanceof TypeError) logger.notice('No creator associated')
@@ -143,25 +163,38 @@ exports.getAgents = (ebook, lcRels) => {
   }
 
   // Search RDF document for all marcrel relationships and create Agents
-  lcRels.forEach((rel) => {
-    const roleTerm = `marcrel:${rel[0]}`
-
-    if (roleTerm in ebook) {
-      try {
-        const ent = exports.getAgent(ebook[roleTerm][0]['pgterms:agent'][0], rel[1])
-        agents.push(ent)
-      } catch (err) {
-        // Do nothing
-      }
-    }
-  })
+  const relAgents = await getMARCRelAgents(lcRels, ebook)
+  agents.push(...relAgents)
 
   return agents
 }
 
+const getAgentVIAF = async (newAgent, queryType) => {
+  try {
+    const resp = await Axios.get('https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup', {
+      params: {
+        queryName: newAgent.name,
+        queryType,
+      },
+    })
+    const viafData = resp.data
+    if ('viaf' in viafData) {
+      newAgent.viaf = viafData.viaf
+      newAgent.lcnaf = viafData.lcnaf
+      if (viafData.name !== newAgent.name) {
+        newAgent.aliases.push(newAgent.name)
+        newAgent.name = viafData.name
+      }
+    }
+  } catch (err) {
+    // Nothing to do, just skip the enhancement
+  }
+
+  return true
+}
 
 // This function explicitly creates each agent
-exports.getAgent = (agent, role) => {
+exports.getAgent = async (agent, role) => {
   // By default we know the role, and likely do not have a website/link
   const entRec = { role, webpage: null }
 
@@ -194,25 +227,7 @@ exports.getAgent = (agent, role) => {
   const corporateRoles = ['publisher', 'manufacturer']
   const queryType = corporateRoles.indexOf(role) > -1 ? 'corporate' : 'personal'
 
-  Axios.get('https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup', {
-    params: {
-      queryName: newAgent.name,
-      queryType,
-    },
-  })
-    .then((response) => {
-      if ('viaf' in response) {
-        newAgent.viaf = response.viaf
-        newAgent.lcnaf = response.lcnaf
-        if (response.name !== newAgent.name) {
-          newAgent.aliases.push(newAgent.name)
-          newAgent.name = response.name
-        }
-      }
-    })
-    .catch(() => {
-      // Skip this lookup, its not necessary
-    })
+  await getAgentVIAF(newAgent, queryType)
 
   return newAgent
 }

--- a/test/fetchHelpers.test.js
+++ b/test/fetchHelpers.test.js
@@ -1,15 +1,16 @@
-/* eslint-disable semi, no-unused-expressions */
+/* eslint-disable semi, no-undef, no-unused-expressions */
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import chaiFs from 'chai-fs'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
-import Helpers from '../src/fetchHelpers.js'
+import Helpers from '../src/fetchHelpers'
+
 chai.should()
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
 chai.use(chaiFs)
-const expect = chai.expect
+const { expect } = chai
 
 describe('Fetch Helpers [fetchHelpers.js]', () => {
   beforeEach(() => {
@@ -38,7 +39,7 @@ describe('Fetch Helpers [fetchHelpers.js]', () => {
     })
 
     it('should process a list of objects from the csvfile', async () => {
-      let rows = await Helpers.loadFromCSV()
+      const rows = await Helpers.loadFromCSV()
       expect(rows).to.have.lengthOf(268)
       expect(rows).to.deep.include(['aut', 'author'])
     })
@@ -46,18 +47,18 @@ describe('Fetch Helpers [fetchHelpers.js]', () => {
 
   describe('exports.loadLCRels', () => {
     it('should parse CSV contents into an array', async () => {
-      var csvStub = sinon.stub(Helpers, 'loadFromCSV')
+      const csvStub = sinon.stub(Helpers, 'loadFromCSV')
       csvStub.resolves([['aut', 'author']])
-      let results = await Helpers.loadLCRels()
+      const results = await Helpers.loadLCRels()
       expect(JSON.stringify(results)).to.equal(JSON.stringify([['aut', 'author']]))
       csvStub.restore()
     })
 
     it('should throw an error if CSV cannot be parsed', async () => {
-      var csvStub = sinon.stub(Helpers, 'loadFromCSV')
+      const csvStub = sinon.stub(Helpers, 'loadFromCSV')
       csvStub.rejects(new Error())
       try {
-        let results = await Helpers.loadLCRels()
+        await Helpers.loadLCRels()
       } catch (err) {
         expect(err).to.be.instanceof(Error)
         expect(err.message).to.equal('Unable to load LC Relations from CSV file')

--- a/test/kinesisOutput.test.js
+++ b/test/kinesisOutput.test.js
@@ -1,59 +1,60 @@
-/* eslint-disable semi, no-unused-expressions */
+/* eslint-disable semi, no-undef, no-unused-expressions */
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import sinonChai from 'sinon-chai'
 import nock from 'nock'
-import Kinesis from '../src/kinesisOutput.js'
+import Kinesis from '../src/kinesisOutput'
+
 chai.should()
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
-const expect = chai.expect
+const { expect } = chai
 
 describe('Kinesis Output [kinesisOutput.js]', () => {
   describe('exports.resultHandler()', () => {
     it('should return success message on kinesis success', async () => {
-      let kinesisMsg = nock('https://kinesis.us-east-1.amazonaws.com')
+      nock('https://kinesis.us-east-1.amazonaws.com')
         .post('/')
         .reply(200, {
-          'EncryptionType': 'NONE',
-          'SequenceNumber': '0000001',
-          'ShardId': 'Shard-0000000000'
+          EncryptionType: 'NONE',
+          SequenceNumber: '0000001',
+          ShardId: 'Shard-0000000000',
         })
-      let mockData = {
-        'gutenbergID': '0000',
-        'data': {
-          'title': 'Hello',
-          'alt_titles': 'Test Data',
-          'entities': [],
-          'subjects': []
+      const mockData = {
+        gutenbergID: '0000',
+        data: {
+          title: 'Hello',
+          alt_titles: 'Test Data',
+          entities: [],
+          subjects: [],
         },
-        'status': 200,
-        'message': 'Retrieved Gutenberg Metadata'
+        status: 200,
+        message: 'Retrieved Gutenberg Metadata',
       }
-      let kinResp = await Kinesis.resultHandler(mockData)
-      expect(kinResp['EncryptionType']).to.equal('NONE')
-      expect(kinResp['SequenceNumber']).to.equal('0000001')
-      expect(kinResp['ShardId']).to.equal('Shard-0000000000')
+      const kinResp = await Kinesis.resultHandler(mockData)
+      expect(kinResp.EncryptionType).to.equal('NONE')
+      expect(kinResp.SequenceNumber).to.equal('0000001')
+      expect(kinResp.ShardId).to.equal('Shard-0000000000')
     })
 
     it('should return failuer message if kinesis put fails', async () => {
-      let kinesisErr = nock('https://kinesis.us-east-1.amazonaws.com')
+      nock('https://kinesis.us-east-1.amazonaws.com')
         .post('/')
-        .reply(404, { 'message': 'Kinesis Put Failed!' })
-      let mockData = {
-        'gutenbergID': '0000',
-        'data': {
-          'title': 'Failure',
-          'alt_titles': 'Test Fail Data',
-          'entities': [],
-          'subjects': []
+        .reply(404, { message: 'Kinesis Put Failed!' })
+      const mockData = {
+        gutenbergID: '0000',
+        data: {
+          title: 'Failure',
+          alt_titles: 'Test Fail Data',
+          entities: [],
+          subjects: [],
         },
-        'status': 200,
-        'message': 'Retrieved Gutenberg Metadata'
+        status: 200,
+        message: 'Retrieved Gutenberg Metadata'
       }
-      let kinResp = await Kinesis.resultHandler(mockData)
-      expect(kinResp['message']).to.equal('Kinesis Put Failed!')
-      expect(kinResp['statusCode']).to.equal(404)
+      const kinResp = await Kinesis.resultHandler(mockData)
+      expect(kinResp.message).to.equal('Kinesis Put Failed!')
+      expect(kinResp.statusCode).to.equal(404)
     })
   })
 })

--- a/test/parseRDF.test.js
+++ b/test/parseRDF.test.js
@@ -213,7 +213,7 @@ describe('RDF Parser [parseRDF.js]', () => {
   })
 
   describe('exports.loadGutenbergRecord()', () => {
-    it('should return a valid JSON object', () => {
+    it('should return a valid JSON object', async () => {
       const formatStub = sinon.stub(RDFParser, 'getFormats')
       const subjectStub = sinon.stub(RDFParser, 'getSubjects')
       const entityStub = sinon.stub(RDFParser, 'getAgents')
@@ -230,7 +230,7 @@ describe('RDF Parser [parseRDF.js]', () => {
 
       attribStub.returns('Test Attrib')
 
-      const parsedData = RDFParser.loadGutenbergRecord(jsonInput, testLC)
+      const parsedData = await RDFParser.loadGutenbergRecord(jsonInput, testLC)
       expect(parsedData.title).to.equal('Test Value')
       expect(parsedData.instances).to.have.lengthOf(1)
       expect(parsedData.instances[0].formats).to.have.lengthOf(2)

--- a/test/parseRDF.test.js
+++ b/test/parseRDF.test.js
@@ -1,22 +1,24 @@
+/* eslint-disable no-undef */
 /* eslint-disable semi, no-unused-expressions */
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
+import nock from 'nock'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
-import RDFParser from '../src/parseRDF.js'
-import { Format } from '../src/sfrMetadataModel.js'
+import RDFParser from '../src/parseRDF'
+import { Format } from '../src/sfrMetadataModel'
 
 chai.should()
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
-const expect = chai.expect
+const { expect } = chai
 
 describe('RDF Parser [parseRDF.js]', () => {
   const testData = {
-    'data': {
-      'repository': {
-        'object': {
-          'text':
+    data: {
+      repository: {
+        object: {
+          text:
                   `
                     <?xml version="1.0" encoding="utf-8"?>
                     <rdf:RDF xml:base="http://www.gutenberg.org/"
@@ -97,66 +99,66 @@ describe('RDF Parser [parseRDF.js]', () => {
                         <dcterms:description>en.wikipedia</dcterms:description>
                       </rdf:Description>
                     </rdf:RDF>
-                  `
-        }
-      }
-    }
+                  `,
+        },
+      },
+    },
   }
 
   const testLC = [
-    ['aut', 'author']
+    ['aut', 'author'],
   ]
 
   const jsonInput = JSON.parse('{"$":{"xml:base":"http://www.gutenberg.org/","xmlns:cc":"http://web.resource.org/cc/","xmlns:dcam":"http://purl.org/dc/dcam/","xmlns:rdf":"http://www.w3.org/1999/02/22-rdf-syntax-ns#","xmlns:rdfs":"http://www.w3.org/2000/01/rdf-schema#","xmlns:dcterms":"http://purl.org/dc/terms/","xmlns:pgterms":"http://www.gutenberg.org/2009/pgterms/"},"pgterms:ebook":[{"$":{"rdf:about":"ebooks/6248"},"pgterms:downloads":[{"_":"0","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#integer"}}],"dcterms:hasFormat":[{"pgterms:file":[{"$":{"rdf:about":"http://www.gutenberg.org/ebooks/6248.epub.images"},"dcterms:format":[{"rdf:Description":[{"$":{"rdf:nodeID":"Nee6588f09c0649cf9486a8a25d04a6fe"},"dcam:memberOf":[{"$":{"rdf:resource":"http://purl.org/dc/terms/IMT"}}],"rdf:value":[{"_":"application/epub+zip","$":{"rdf:datatype":"http://purl.org/dc/terms/IMT"}}]}]}],"dcterms:isFormatOf":[{"$":{"rdf:resource":"ebooks/6248"}}],"dcterms:modified":[{"_":"2018-10-28T13:20:08.823859","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#dateTime"}}],"dcterms:extent":[{"_":"47995","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#integer"}}]}]},{"pgterms:file":[{"$":{"rdf:about":"http://www.gutenberg.org/ebooks/6248.epub.noimages"},"dcterms:format":[{"rdf:Description":[{"$":{"rdf:nodeID":"N192c343cdd614778b2be088b6222c968"},"dcam:memberOf":[{"$":{"rdf:resource":"http://purl.org/dc/terms/IMT"}}],"rdf:value":[{"_":"application/epub+zip","$":{"rdf:datatype":"http://purl.org/dc/terms/IMT"}}]}]}],"dcterms:isFormatOf":[{"$":{"rdf:resource":"ebooks/6248"}}],"dcterms:modified":[{"_":"2018-10-28T13:20:08.867863","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#dateTime"}}],"dcterms:extent":[{"_":"47995","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#integer"}}]}]}],"dcterms:rights":["Public domain in the USA."],"dcterms:subject":[{"rdf:Description":[{"$":{"rdf:nodeID":"Ne41bbb52df5f4dbf98b4ab783ed42c34"},"dcam:memberOf":[{"$":{"rdf:resource":"http://purl.org/dc/terms/LCC"}}],"rdf:value":["PS"]}]}],"dcterms:publisher":["Project Gutenberg"],"dcterms:type":[{"rdf:Description":[{"$":{"rdf:nodeID":"Ncf637b5118f74aad940dbfd983af9ef9"},"dcam:memberOf":[{"$":{"rdf:resource":"http://purl.org/dc/terms/DCMIType"}}],"rdf:value":["Text"]}]}],"dcterms:issued":[{"_":"2004-08-01","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#date"}}],"dcterms:creator":[{"pgterms:agent":[{"$":{"rdf:about":"2009/agents/1285"},"pgterms:birthdate":[{"_":"1862","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#integer"}}],"pgterms:alias":["Parker, Gilbert, Sir, bart.","Parker, Horatio Gilbert"],"pgterms:webpage":[{"$":{"rdf:resource":"http://en.wikipedia.org/wiki/Gilbert_Parker"}}],"pgterms:name":["Parker, Gilbert"],"pgterms:deathdate":[{"_":"1932","$":{"rdf:datatype":"http://www.w3.org/2001/XMLSchema#integer"}}]}]}],"dcterms:license":[{"$":{"rdf:resource":"license"}}],"dcterms:language":[{"rdf:Description":[{"$":{"rdf:nodeID":"Nec9eb8e544184a32abd81186ed79f05b"},"rdf:value":[{"_":"en","$":{"rdf:datatype":"http://purl.org/dc/terms/RFC4646"}}]}]}],"dcterms:title":["Michel and Angele [A Ladder of Swords], Volume 1."]}],"cc:Work":[{"$":{"rdf:about":""},"rdfs:comment":["Archives containing the RDF files for *all* our books can be downloaded at http://www.gutenberg.org/wiki/Gutenberg:Feeds#The_Complete_Project_Gutenberg_Catalog"],"cc:license":[{"$":{"rdf:resource":"https://creativecommons.org/publicdomain/zero/1.0/"}}]}],"rdf:Description":[{"$":{"rdf:about":"http://en.wikipedia.org/wiki/Gilbert_Parker"},"dcterms:description":["en.wikipedia"]}]}')
 
   const jsonData = {
-    'title': 'Michel and Angele [A Ladder of Swords], Volume 1.',
-    'publisher': 'Project Gutenberg',
-    'rightsStmt': 'Public domain in the USA.',
-    'license': 'https://creativecommons.org/publicdomain/zero/1.0/',
-    'entities': [{
-      'name': 'Parker, Gilbert',
-      'aliases': ['Parker, Horatio Gilbert', 'Parker, Gilbert, Sir, bart.'],
-      'birth': '1862',
-      'death': '1932',
-      'website': 'http://en.wikipedia.org/wiki/Gilbert_Parker',
-      'role': 'author'
+    title: 'Michel and Angele [A Ladder of Swords], Volume 1.',
+    publisher: 'Project Gutenberg',
+    rightsStmt: 'Public domain in the USA.',
+    license: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    entities: [{
+      name: 'Parker, Gilbert',
+      aliases: ['Parker, Horatio Gilbert', 'Parker, Gilbert, Sir, bart.'],
+      birth: '1862',
+      death: '1932',
+      website: 'http://en.wikipedia.org/wiki/Gilbert_Parker',
+      role: 'author',
     }],
-    'subjects': [{
-      'term': 'PS',
-      'authority': 'LCC'
+    subjects: [{
+      term: 'PS',
+      authority: 'LCC',
     }],
-    'formats': [
+    formats: [
       {
-        'url': 'http://www.gutenberg.org/ebooks/6248.epub.noimages',
-        'updated': '2018-11-15',
-        'size': '1235432'
+        url: 'http://www.gutenberg.org/ebooks/6248.epub.noimages',
+        updated: '2018-11-15',
+        size: '1235432',
       }, {
-        'url': 'http://www.gutenberg.org/ebooks/6248.epub.images',
-        'updated': '2018-11-15',
-        'size': '21543253'
-      }
-    ]
+        url: 'http://www.gutenberg.org/ebooks/6248.epub.images',
+        updated: '2018-11-15',
+        size: '21543253',
+      },
+    ],
   }
 
   describe('exports.parseRDF()', () => {
     it('should return data object with successful parse', () => {
-      let gutStub = sinon.stub(RDFParser, 'loadGutenbergRecord')
+      const gutStub = sinon.stub(RDFParser, 'loadGutenbergRecord')
       gutStub.returns(jsonData)
       RDFParser.parseRDF(testData, 1, 'https://gutenberg.org/1', testLC, (err, data) => {
         expect(data).to.not.equal(null)
-        expect(data['title']).to.equal('Michel and Angele [A Ladder of Swords], Volume 1.')
+        expect(data.title).to.equal('Michel and Angele [A Ladder of Swords], Volume 1.')
       })
       gutStub.restore()
     })
 
     it('should return error if XML cannot be parsed', () => {
-      let gutStub = sinon.stub(RDFParser, 'loadGutenbergRecord')
-      let badXML = {
-        'data': {
-          'repository': {
-            'object': {
-              'text':
+      const gutStub = sinon.stub(RDFParser, 'loadGutenbergRecord')
+      const badXML = {
+        data: {
+          repository: {
+            object: {
+              text:
                       `
                         <?xml version="1.0" encoding="utf-8">
                         <dcterms:hasFormat>
@@ -198,12 +200,12 @@ describe('RDF Parser [parseRDF.js]', () => {
                       <rdf:Description rdf:about="http://en.wikipedia.org/wiki/Gilbert_Parker">
                         <dcterms:description>en.wikipedia</dcterms:description>
                       </rdf:Description>
-                      `
-            }
-          }
-        }
+                      `,
+            },
+          },
+        },
       }
-      RDFParser.parseRDF(badXML, 1, 'https://gutenberg.org/1', testLC, (err, data) => {
+      RDFParser.parseRDF(badXML, 1, 'https://gutenberg.org/1', testLC, (err) => {
         expect(err).to.not.equal(null)
       })
       gutStub.restore()
@@ -212,27 +214,27 @@ describe('RDF Parser [parseRDF.js]', () => {
 
   describe('exports.loadGutenbergRecord()', () => {
     it('should return a valid JSON object', () => {
-      let formatStub = sinon.stub(RDFParser, 'getFormats')
-      let subjectStub = sinon.stub(RDFParser, 'getSubjects')
-      let entityStub = sinon.stub(RDFParser, 'getAgents')
-      let fieldStub = sinon.stub(RDFParser, 'getRecordField')
-      let attribStub = sinon.stub(RDFParser, 'getFieldAttrib')
+      const formatStub = sinon.stub(RDFParser, 'getFormats')
+      const subjectStub = sinon.stub(RDFParser, 'getSubjects')
+      const entityStub = sinon.stub(RDFParser, 'getAgents')
+      const fieldStub = sinon.stub(RDFParser, 'getRecordField')
+      const attribStub = sinon.stub(RDFParser, 'getFieldAttrib')
 
       formatStub.returns([new Format('test', 'test', 'test'), new Format('test', 'test', 'test')])
 
-      subjectStub.returns(jsonData['subjects'])
+      subjectStub.returns(jsonData.subjects)
 
-      entityStub.returns(jsonData['entities'])
+      entityStub.returns(jsonData.entities)
 
       fieldStub.returns('Test Value')
 
       attribStub.returns('Test Attrib')
 
-      let parsedData = RDFParser.loadGutenbergRecord(jsonInput, testLC)
-      expect(parsedData['title']).to.equal('Test Value')
-      expect(parsedData['instances']).to.have.lengthOf(1)
-      expect(parsedData['instances'][0]['formats']).to.have.lengthOf(2)
-      expect(parsedData['agents'][0]['name']).to.equal('Parker, Gilbert')
+      const parsedData = RDFParser.loadGutenbergRecord(jsonInput, testLC)
+      expect(parsedData.title).to.equal('Test Value')
+      expect(parsedData.instances).to.have.lengthOf(1)
+      expect(parsedData.instances[0].formats).to.have.lengthOf(2)
+      expect(parsedData.agents[0].name).to.equal('Parker, Gilbert')
 
       formatStub.restore()
       subjectStub.restore()
@@ -243,53 +245,78 @@ describe('RDF Parser [parseRDF.js]', () => {
   })
 
   describe('exports.getAgents()', () => {
-    let entStub = sinon.stub(RDFParser, 'getAgent')
-    it('should return single entity for creator', () => {
-      entStub.returns(jsonData['entities'][0])
-      let creator = RDFParser.getAgents(jsonInput['pgterms:ebook'][0], testLC)
+    const entStub = sinon.stub(RDFParser, 'getAgent')
+    it('should return single entity for creator', async () => {
+      entStub.returns(jsonData.entities[0])
+      const creator = await RDFParser.getAgents(jsonInput['pgterms:ebook'][0], testLC)
       expect(creator).to.have.lengthOf(1)
-      expect(creator[0]['role']).to.equal('author')
-      expect(creator[0]['name']).to.equal('Parker, Gilbert')
+      expect(creator[0].role).to.equal('author')
+      expect(creator[0].name).to.equal('Parker, Gilbert')
       entStub.restore()
     })
 
-    it('should return empty array if no creator is found', () => {
-      let jsonNoCreator = Object.assign({}, jsonInput['pgterms:ebook'][0])
+    it('should return empty array if no creator is found', async () => {
+      const jsonNoCreator = { ...jsonInput['pgterms:ebook'][0] }
       delete jsonNoCreator['dcterms:creator']
-      let noCreator = RDFParser.getAgents(jsonNoCreator, testLC)
+      const noCreator = await RDFParser.getAgents(jsonNoCreator, testLC)
       expect(noCreator).to.have.lengthOf(0)
     })
 
-    it('should return an entity for marcrel codes', () => {
-      let jsonAutCreator = Object.assign({}, jsonInput['pgterms:ebook'][0])
+    it('should return an entity for marcrel codes', async () => {
+      nock('https://dev-platform.nypl.org')
+        .get('/api/v0.1/research-now/viaf-lookup')
+        .query(true)
+        .reply(200, {
+          name: 'Parker, Gilbert Test',
+          viaf: 'XXXXXXXXX',
+          lcnaf: 'n000000000',
+        })
+      const jsonAutCreator = { ...jsonInput['pgterms:ebook'][0] }
       jsonAutCreator['marcrel:aut'] = jsonAutCreator['dcterms:creator']
       delete jsonAutCreator['dcterms:creator']
-      let autCreator = RDFParser.getAgents(jsonAutCreator, testLC)
+      const autCreator = await RDFParser.getAgents(jsonAutCreator, testLC)
       expect(autCreator).to.have.lengthOf(1)
-      expect(autCreator[0]['roles'][0]).to.equal('author')
-      expect(autCreator[0]['name']).to.equal('Parker, Gilbert')
+      expect(autCreator[0].roles[0]).to.equal('author')
+      expect(autCreator[0].name).to.equal('Parker, Gilbert Test')
     })
   })
 
   describe('exports.getAgent()', () => {
-    it('should return entity object', () => {
-      let ent = jsonInput['pgterms:ebook'][0]['dcterms:creator'][0]['pgterms:agent'][0]
-      let entity = RDFParser.getAgent(ent, 'author')
-      expect(entity).to.include({ 'name': 'Parker, Gilbert'})
-      expect(entity['roles'][0]).to.equal('author')
+    it('should return entity object', async () => {
+      nock('https://dev-platform.nypl.org')
+        .get('/api/v0.1/research-now/viaf-lookup')
+        .query(true)
+        .reply(200, {
+          name: 'Parker, Gilbert Test',
+          viaf: 'XXXXXXXXX',
+          lcnaf: 'n000000000',
+        })
+      const ent = jsonInput['pgterms:ebook'][0]['dcterms:creator'][0]['pgterms:agent'][0]
+      const entity = await RDFParser.getAgent(ent, 'author')
+      expect(entity).to.include({ name: 'Parker, Gilbert Test' })
+      expect(entity.roles[0]).to.equal('author')
+      expect(entity.viaf).to.equal('XXXXXXXXX')
     })
 
-    it('should include a webpage if it exists', () => {
-      let ent = jsonInput['pgterms:ebook'][0]['dcterms:creator'][0]['pgterms:agent'][0]
-      let entity = RDFParser.getAgent(ent, 'author')
-      expect(entity['link']).to.include({'url': 'http://en.wikipedia.org/wiki/Gilbert_Parker' })
+    it('should include a webpage if it exists', async () => {
+      nock('https://dev-platform.nypl.org')
+        .get('/api/v0.1/research-now/viaf-lookup')
+        .query(true)
+        .reply(200, {
+          name: 'Parker, Gilbert Test',
+          viaf: 'XXXXXXXXX',
+          lcnaf: 'n000000000',
+        })
+      const ent = jsonInput['pgterms:ebook'][0]['dcterms:creator'][0]['pgterms:agent'][0]
+      const entity = await RDFParser.getAgent(ent, 'author')
+      expect(entity.link).to.include({ url: 'http://en.wikipedia.org/wiki/Gilbert_Parker' })
     })
   })
 
   describe('exports.getSubjects()', () => {
     it('should return an array of subjects', () => {
-      let subjects = jsonInput['pgterms:ebook'][0]['dcterms:subject']
-      let subjReturn = RDFParser.getSubjects(subjects)
+      const subjects = jsonInput['pgterms:ebook'][0]['dcterms:subject']
+      const subjReturn = RDFParser.getSubjects(subjects)
       expect(subjReturn).to.have.lengthOf(1)
       expect(subjReturn[0].subject).to.equal('PS')
       expect(subjReturn[0].authority).to.equal('LCC')
@@ -297,7 +324,8 @@ describe('RDF Parser [parseRDF.js]', () => {
   })
 
   describe('exports.getFormats()', () => {
-    let recStub, attribStub
+    let recStub
+    let attribStub
     beforeEach(() => {
       recStub = sinon.stub(RDFParser, 'getRecordField')
       attribStub = sinon.stub(RDFParser, 'getFieldAttrib')
@@ -320,32 +348,31 @@ describe('RDF Parser [parseRDF.js]', () => {
 
   describe('exports.getRecordField()', () => {
     it('should return a value for a field with a primitive value', () => {
-      let testRec = { 'test': ['value'] }
-      let testField = 'test'
-      let testResp = RDFParser.getRecordField(testRec, testField)
+      const testRec = { test: ['value'] }
+      const testField = 'test'
+      const testResp = RDFParser.getRecordField(testRec, testField)
       expect(testResp).to.equal('value')
     })
 
     it('should return a value for a field with an object', () => {
-      let testRec = { 'test': [{ _: 'value', 'something': 'else' }] }
-      let testField = 'test'
-      let testResp = RDFParser.getRecordField(testRec, testField)
+      const testRec = { test: [{ _: 'value', something: 'else' }] }
+      const testField = 'test'
+      const testResp = RDFParser.getRecordField(testRec, testField)
       expect(testResp).to.equal('value')
     })
 
     it('should return an empty string if field is not found', () => {
-      let testRec = null
-      let testField = 'test'
-      let testResp = RDFParser.getRecordField(null, testField)
+      const testField = 'test'
+      const testResp = RDFParser.getRecordField(null, testField)
       expect(testResp).to.equal('')
     })
   })
 
   describe('exports.getFieldAttrib()', () => {
     it('should return a value if attrib exists', () => {
-      let testField = { '$': { 'attrib1': 'attrib1' }, 'value': 'value' }
-      let testAttrib = 'attrib1'
-      let attribResp = RDFParser.getFieldAttrib(testField, testAttrib)
+      const testField = { $: { attrib1: 'attrib1' }, value: 'value' }
+      const testAttrib = 'attrib1'
+      const attribResp = RDFParser.getFieldAttrib(testField, testAttrib)
       expect(attribResp).to.equal('attrib1')
     })
   })


### PR DESCRIPTION
This adds a lookup for VIAF/LCNAF identifiers at the initial fetch stage for Gutenberg records as this is no longer done in the database layer. This should improve the accuracy for agent matching for records from Gutenberg. 

This meant promise-fying the parser, which works in the functional tests that have been run.

This also includes some linting fixes for the test classes to make the test suite nicer to work with.